### PR TITLE
Compiller is do not accept const implies at end

### DIFF
--- a/src/server/game/Grids/NGrid.h
+++ b/src/server/game/Grids/NGrid.h
@@ -89,7 +89,7 @@ class NGrid
         }
 
         uint32 GetGridId(void) const { return i_gridId; }
-        void SetGridId(const uint32 id) const { i_gridId = id; }
+        void SetGridId(const uint32 & id) { i_gridId = id; }
         grid_state_t GetGridState(void) const { return i_cellstate; }
         void SetGridState(grid_state_t s) { i_cellstate = s; }
         int32 getX() const { return i_x; }


### PR DESCRIPTION
On different compilers this can be purpose of fail of compilation.