### PR TITLE
Fix spells being added double/tripple to actionbar

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -2689,7 +2689,7 @@ void Player::GiveLevel(uint8 level)
     SetCreateHealth(0);
     SetCreateMana(basemana);
 
-    InitTalentForLevel();
+    InitTalentForLevel(); //spells are added to action bar in here when leveling up (and more)
     InitTaxiNodesForLevel();
 
     //if (level < PLAYER_LEVEL_MIN_HONOR)
@@ -2731,8 +2731,8 @@ void Player::InitTalentForLevel()
 {
     uint8 level = getLevel();
     // talents base at level diff (talents = level - 9 but some can be used already)
-    if (level < MIN_SPECIALIZATION_LEVEL)
-        ResetTalentSpecialization();
+    //if (level < MIN_SPECIALIZATION_LEVEL)
+        //ResetTalentSpecialization(); //spells getting added double/tripple to action bar cuz of this
 
     int32 talentTiers = DB2Manager::GetNumTalentsAtLevel(level, Classes(getClass()));
     if (level < 15)


### PR DESCRIPTION
disabled 2 lines of code that seem to do nothing but create bugs. tested with multiple characters and didn't find any downside of disabling this. The benefit is that spells are added to the action bar correctly when leveling up.